### PR TITLE
Use uv base image and run Streamlit

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,26 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: ["main"]
+    tags: ["v*"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/llm-pdf-translator:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,12 @@
-FROM ubuntu:22.04
-
-ENV DEBIAN_FRONTEND=noninteractive \
-    PIP_PREFER_BINARY=1 \
-    DEBCONF_NOWARNINGS=yes
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh
-
-RUN apt-get update \
-    && apt-get -y upgrade \
-    && apt-get install -y \
-        poppler-utils \
-        libpoppler-dev \
-        wget \
-        curl \
-        git \
-        ffmpeg \
-        libsm6 \
-        libxext6 \
-    && curl -LsSf https://astral.sh/uv/install.sh | sh \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /tmp/* /var/tmp/*
+FROM ghcr.io/astral-sh/uv:latest
 
 WORKDIR /app
 
-ADD . /app/
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev
 
-CMD ["bash"]
+COPY . .
+
+EXPOSE 8501
+
+CMD ["uv", "run", "streamlit", "run", "st.py"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,53 @@
-# Work In Progress
+# LLM PDF Translator
 
-This is a work in progress. I'm still working on it.
+LLM PDF Translator summarizes and translates PDF documents using local or hosted large language models.
 
-This code has errors, check back later.
+## Features
+- Summarize a document to provide translation context.
+- Translate PDFs while preserving the original layout.
+- Configure different LLM endpoints via `config.yaml`.
+
+## Configuration
+Edit `config.yaml` to choose the model and base URL for the desired endpoint.
+
+### Ollama
+```yaml
+base_url: http://ollama-gpu:11434
+model: "gemma3:1b"
+```
+The `base_url` must use the container name of your Ollama server (e.g., `ollama-gpu`) when running on the `ollama-network` Docker network.
+
+### OpenRouter
+```yaml
+base_url: "https://openrouter.ai/api/v1"
+model: "google/gemma-3-27b-it:free"
+```
+
+### OpenAI
+```yaml
+base_url: "https://api.openai.com/v1"
+model: "gpt-4o-mini"
+```
+
+When using OpenRouter or OpenAI, update `core/translate.py` to initialize `OpenAIClient` instead of `OllamaClient` so that the correct API client is used.
+
+## Environment Variables
+Create a `.env` file with the necessary API keys:
+```
+OPENAI_API_KEY=your-openai-key
+OPENROUTER_API_KEY=your-openrouter-key
+```
+Only the key for the chosen endpoint is required.
+
+## Build and Run
+Build the Docker image:
+```bash
+docker build -t llm-pdf-translator .
+```
+
+Run the container, mapping the Streamlit port and connecting to the Ollama network:
+```bash
+docker run --rm -it --network=ollama-network -p 8765:8501 llm-pdf-translator
+```
+
+The app will be available at `http://localhost:8765`.


### PR DESCRIPTION
## Summary
- simplify Dockerfile using the `ghcr.io/astral-sh/uv` image
- install Python dependencies with `uv sync --frozen`
- run the app with `uv run streamlit run st.py`
- expose Streamlit's port for easier access
- document features, configuration, and container usage in the README
- add GitHub Actions workflow to build and push the Docker image to Docker Hub

## Testing
- `python -m py_compile st.py styles.py core/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6271b86b08323a278972b1c138f48