### PR TITLE
Add word-count gate to rewriting pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# LLM PDF Translator
+# LLM PDF Rewriter
 
-LLM PDF Translator summarizes and translates PDF documents using local or hosted large language models.
+LLM PDF Rewriter summarizes and rewrites PDF documents using local or hosted large language models.
 
 ## Features
-- Summarize a document to provide translation context.
-- Translate PDFs while preserving the original layout.
+- Summarize a document to provide rewriting context.
+- Rewrite PDFs while preserving the original layout.
 - Configure different LLM endpoints via `config.yaml`.
 
 ## Configuration
@@ -29,7 +29,7 @@ base_url: "https://api.openai.com/v1"
 model: "gpt-4o-mini"
 ```
 
-When using OpenRouter or OpenAI, update `core/translate.py` to initialize `OpenAIClient` instead of `OllamaClient` so that the correct API client is used.
+When using OpenRouter or OpenAI, update `core/rewrite.py` to initialize `OpenAIClient` instead of `OllamaClient` so that the correct API client is used.
 
 ## Environment Variables
 Create a `.env` file with the necessary API keys:
@@ -42,12 +42,12 @@ Only the key for the chosen endpoint is required.
 ## Build and Run
 Build the Docker image:
 ```bash
-docker build -t llm-pdf-translator .
+docker build -t llm-pdf-rewriter .
 ```
 
 Run the container, mapping the Streamlit port and connecting to the Ollama network:
 ```bash
-docker run --rm -it --network=ollama-network -p 8765:8501 llm-pdf-translator
+docker run --rm -it --network=ollama-network -p 8765:8501 llm-pdf-rewriter
 ```
 
 The app will be available at `http://localhost:8765`.

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,6 @@
-base_url: http://ollama:11434
+# base_url: http://ollama:11434
 # base_url: "https://openrouter.ai/api/v1"
-model: "gemma3:1b"
+# model: "gemma3:1b"
 # model: "google/gemma-3-27b-it:free"
+base_url: "https://api.openai.com/v1"
+model: "gpt-5-nano"

--- a/core/prompt.py
+++ b/core/prompt.py
@@ -1,7 +1,7 @@
 def summarize_prompt(chunk: str) -> str:
     prompt = f"""
     ### Instructions
-    Summarize the following text concisely. Keep the main meaning, clarity, and tone. 
+    Summarize the following text concisely. Keep the main meaning, clarity, and tone.
     Remove redundancy, simplify phrasing, and output only the summary text with no prefatory phrases or explanations.
 
     ### Input
@@ -12,32 +12,31 @@ def summarize_prompt(chunk: str) -> str:
     return prompt
 
 
-def translate_prompt(chunk: str, source_lang: str, target_lang: str) -> str:
+def rewrite_prompt(chunk: str, instruction: str) -> str:
     prompt = f"""
     ### Instructions
-    Translate the following text from {source_lang} to {target_lang}. 
-    Output only the translated text with no explanations or extra phrases.
+    You will rewrite the provided text according to this request: {instruction}
+    Preserve the core meaning, keep facts accurate, and ensure the output is fluent and readable.
+    Return only the rewritten text without commentary.
 
-    ### Input
+    ### Text
     {chunk}
 
-    ### Translation
+    ### Rewritten Text
     """
     return prompt
 
 
-def translate_prompt_with_context(
+def rewrite_prompt_with_context(
     chunk: str,
     summary: str,
-    source_lang: str,
-    target_lang: str,
+    instruction: str,
 ) -> str:
     prompt = f"""
     ### Instructions
-    Translate the provided text from {source_lang} to {target_lang}.
-    Keep in mind the context provided, to help with translation.
-    Don't translate names, dates, numbers, or formulas.
-    Output only the translated text with no explanations or extra phrases.
+    Rewrite the provided text according to this request: {instruction}
+    Use the context to stay consistent with the overall document meaning.
+    Keep facts accurate and output only the rewritten text without commentary.
 
     ### Context
     {summary}
@@ -45,6 +44,6 @@ def translate_prompt_with_context(
     ### Text
     {chunk}
 
-    ### Translation
+    ### Rewritten Text
     """
     return prompt

--- a/core/rewrite.py
+++ b/core/rewrite.py
@@ -5,43 +5,56 @@ import pymupdf
 from core.client.base import BaseClient
 from core.client.ollama import OllamaClient
 from core.extract import extract_text
-from core.prompt import translate_prompt, translate_prompt_with_context
+from core.prompt import rewrite_prompt, rewrite_prompt_with_context
 from core.summarize import summarize_doc
 
 
-def translate_chunk(
-    chunk: str, source_lang: str, target_lang: str, client: BaseClient = None
-) -> str:
+MIN_WORDS_TO_REWRITE = 10
+
+
+def _should_rewrite(text: str, threshold: int = MIN_WORDS_TO_REWRITE) -> bool:
+    """Return True when the text exceeds the rewrite word threshold."""
+
+    words = text.split()
+    return len(words) > threshold
+
+
+def rewrite_chunk(chunk: str, instruction: str, client: BaseClient = None) -> str:
     if client is None:
         return ""
-    prompt = translate_prompt(chunk, source_lang, target_lang)
+
+    if not _should_rewrite(chunk):
+        return chunk
+    prompt = rewrite_prompt(chunk, instruction)
     resp = client.ask(prompt)
     return resp
 
 
-def translate_chunk_with_context(
+def rewrite_chunk_with_context(
     chunk: str,
     summary: str,
-    source_lang: str,
-    target_lang: str,
+    instruction: str,
     client: BaseClient = None,
 ) -> str:
     if client is None:
         return ""
-    prompt = translate_prompt_with_context(chunk, summary, source_lang, target_lang)
+
+    if not _should_rewrite(chunk):
+        return chunk
+
+    prompt = rewrite_prompt_with_context(chunk, summary, instruction)
     resp = client.ask(prompt)
     return resp
 
 
-def translate_pdf(
+def rewrite_pdf(
     pdf_file: IO[bytes],
     config: dict,
-    src_lang: str,
-    tgt_lang: str,
+    instruction: str,
     start_page: int,
     end_page: int,
 ) -> str:
-    """Summarizes the document, then translates each chunk of text"""
+    """Summarizes the document, then rewrites each chunk of text."""
 
     # Initialize client
     client = OllamaClient(
@@ -55,36 +68,29 @@ def translate_pdf(
     # Extract text chunks
     docs = extract_text(pdf_file, chunk_size=3000)
 
-    # Translate each chunk of text
-    translated_chunks = []
-    for i, doc in enumerate(docs):
-        translated_chunk = translate_chunk_with_context(
-            doc, summary, src_lang, tgt_lang, client
-        )
-        translated_chunks.append(translated_chunk)
+    # Rewrite each chunk of text
+    rewritten_chunks = []
+    for doc in docs:
+        rewritten_chunk = rewrite_chunk_with_context(doc, summary, instruction, client)
+        if not rewritten_chunk:
+            rewritten_chunk = doc
+        rewritten_chunks.append(rewritten_chunk)
 
-    all_translations = "\n".join(translated_chunks)
+    all_rewrites = "\n".join(rewritten_chunks)
 
-    #
-    # st.markdown(
-    #     f"<div style='direction: rtl; text-align: right;'>{translated_doc}</div>",
-    #     unsafe_allow_html=True,
-    # )
-
-    return summary, all_translations
+    return summary, all_rewrites
 
 
-def translate_pdf_preserve_layout(
+def rewrite_pdf_preserve_layout(
     pdf_file: IO[bytes],
     output_path: str,
     config: dict,
-    src_lang: str,
-    tgt_lang: str,
+    instruction: str,
     start_page: int,
     end_page: int,
     progress_callback: Callable[[int], None] | None = None,
 ) -> None:
-    """Translate a PDF and write a new PDF preserving the original layout.
+    """Rewrite a PDF and write a new PDF preserving the original layout.
 
     Only pages within ``start_page`` and ``end_page`` (1-indexed, inclusive)
     are processed and included in the output document.
@@ -92,13 +98,7 @@ def translate_pdf_preserve_layout(
 
     client = OllamaClient(model=config["model"], base_url=config["base_url"])
 
-    # client = OpenAIClient(
-    #     api_key=os.environ["OPENROUTER_API_KEY"],
-    #     model=config["model"],
-    #     base_url=config["base_url"],
-    # )
-
-    # Summarize the document to provide translation context
+    # Summarize the document to provide rewriting context
     summary = summarize_doc(
         pdf_file, client, progress_callback=progress_callback, progress_range=(0, 20)
     )
@@ -109,8 +109,6 @@ def translate_pdf_preserve_layout(
     doc = pymupdf.open(stream=pdf_file.read(), filetype="pdf")
     doc.select(list(range(start_page - 1, end_page)))
 
-    rtl = True
-
     font_file1 = "fonts/Yekan.ttf"
     css1 = (
         """@font-face {font-family: sans-serif; src: url("%s");}
@@ -118,7 +116,7 @@ def translate_pdf_preserve_layout(
         % font_file1
     )
 
-    # Count total blocks to translate
+    # Count total blocks to rewrite
     total_blocks = 0
     for i in range(doc.page_count):
         page = doc[i]
@@ -134,21 +132,22 @@ def translate_pdf_preserve_layout(
         page = doc[i]
         blocks = page.get_text("blocks")
         rects = []
-        translations = []
+        rewrites = []
 
         for block in blocks:
             x0, y0, x1, y1, text = block[:5]
             if not text.strip():
                 continue
 
-            translated = translate_chunk_with_context(
-                text, summary, src_lang, tgt_lang, client
-            )
+            if _should_rewrite(text):
+                rewritten = rewrite_chunk_with_context(text, summary, instruction, client)
+                if not rewritten:
+                    rewritten = text
 
-            rect = pymupdf.Rect(x0, y0, x1, y1)
-            rects.append(rect)
-            translations.append(translated)
-            page.add_redact_annot(rect, fill=(1, 1, 1))
+                rect = pymupdf.Rect(x0, y0, x1, y1)
+                rects.append(rect)
+                rewrites.append(rewritten)
+                page.add_redact_annot(rect, fill=(1, 1, 1))
 
             processed_blocks += 1
             if progress_callback and total_blocks:
@@ -158,18 +157,9 @@ def translate_pdf_preserve_layout(
         # Remove only the original text
         page.apply_redactions(images=0, graphics=0, text=0)
 
-        align = 2 if rtl else 0
-        for rect, text in zip(rects, translations):
-            fontsize = rect.y1 - rect.y0 - 1
-            text = f"""
-            <div dir="rtl">{text}</div>
-            """
-            page.insert_htmlbox(rect, text, css=css1)
-            # while fontsize > 5:
-            #     area = page.insert_textbox(rect, text, fontsize=fontsize, fontname="F0")
-            #     if area >= 0:
-            #         break
-            #     fontsize -= 1
+        for rect, text in zip(rects, rewrites):
+            html_text = f"""<div>{text}</div>"""
+            page.insert_htmlbox(rect, html_text, css=css1)
 
     doc.save(output_path)
 

--- a/core/rewrite.py
+++ b/core/rewrite.py
@@ -3,11 +3,12 @@ from typing import IO, Callable
 import pymupdf
 
 from core.client.base import BaseClient
-from core.client.ollama import OllamaClient
+
+# from core.client.ollama import OllamaClient
+from core.client.openai import OpenAIClient
 from core.extract import extract_text
 from core.prompt import rewrite_prompt, rewrite_prompt_with_context
 from core.summarize import summarize_doc
-
 
 MIN_WORDS_TO_REWRITE = 10
 
@@ -57,7 +58,7 @@ def rewrite_pdf(
     """Summarizes the document, then rewrites each chunk of text."""
 
     # Initialize client
-    client = OllamaClient(
+    client = OpenAIClient(
         model=config["model"],
         base_url=config["base_url"],
     )
@@ -96,7 +97,7 @@ def rewrite_pdf_preserve_layout(
     are processed and included in the output document.
     """
 
-    client = OllamaClient(model=config["model"], base_url=config["base_url"])
+    client = OpenAIClient(model=config["model"], base_url=config["base_url"])
 
     # Summarize the document to provide rewriting context
     summary = summarize_doc(
@@ -108,13 +109,6 @@ def rewrite_pdf_preserve_layout(
 
     doc = pymupdf.open(stream=pdf_file.read(), filetype="pdf")
     doc.select(list(range(start_page - 1, end_page)))
-
-    font_file1 = "fonts/Yekan.ttf"
-    css1 = (
-        """@font-face {font-family: sans-serif; src: url("%s");}
-    body {font-family:sans-serif;} """
-        % font_file1
-    )
 
     # Count total blocks to rewrite
     total_blocks = 0
@@ -140,7 +134,9 @@ def rewrite_pdf_preserve_layout(
                 continue
 
             if _should_rewrite(text):
-                rewritten = rewrite_chunk_with_context(text, summary, instruction, client)
+                rewritten = rewrite_chunk_with_context(
+                    text, summary, instruction, client
+                )
                 if not rewritten:
                     rewritten = text
 
@@ -159,7 +155,7 @@ def rewrite_pdf_preserve_layout(
 
         for rect, text in zip(rects, rewrites):
             html_text = f"""<div>{text}</div>"""
-            page.insert_htmlbox(rect, html_text, css=css1)
+            page.insert_htmlbox(rect, html_text)
 
     doc.save(output_path)
 

--- a/st.py
+++ b/st.py
@@ -8,7 +8,7 @@ import yaml
 from dotenv import load_dotenv
 
 from core.extract import get_page_count
-from core.translate import translate_pdf_preserve_layout
+from core.rewrite import rewrite_pdf_preserve_layout
 from styles import apply_custom_styles
 
 CONFIG_FILE = Path("config.yaml")
@@ -35,7 +35,7 @@ def load_config():
 
 # Page configuration
 st.set_page_config(
-    page_title="PDF Translator",
+    page_title="PDF Rewriter",
     page_icon="📄",
     layout="centered",
     initial_sidebar_state="collapsed",
@@ -45,32 +45,12 @@ st.set_page_config(
 apply_custom_styles()
 
 # App title and description
-st.title("📄 LLM PDF Translator")
-
-# Language options
-COMMON_LANGUAGES = [
-    "English",
-    "Persian فارسی",
-    "Spanish",
-    "French",
-    "German",
-    "Italian",
-    "Portuguese",
-    "Russian",
-    "Turkish",
-    "Arabic",
-    "Chinese",
-    "Japanese",
-    "Korean",
-    "Hindi",
-    "Azerbaijani",
-]
+st.title("📄 LLM PDF Rewriter")
 
 
 def validate_inputs(
     pdf_file: IO[bytes],
-    src_lang: str,
-    tgt_lang: str,
+    prompt: str,
     start_page: int,
     end_page: int,
     page_count: int,
@@ -80,8 +60,8 @@ def validate_inputs(
 
     if pdf_file is None:
         errors.append("❌ Please upload a PDF first.")
-    if src_lang == tgt_lang:
-        errors.append("❌ Source and target languages must be different.")
+    if not prompt or not prompt.strip():
+        errors.append("❌ Please provide a rewriting prompt.")
     if end_page < start_page:
         errors.append("❌ End page must be greater than or equal to start page.")
     if page_count and (start_page < 1 or end_page > page_count):
@@ -90,21 +70,13 @@ def validate_inputs(
     return errors
 
 
-def show_translation_summary(pdf_file, start_page, end_page, src_lang, tgt_lang):
-    """Show translation summary metrics."""
-    st.markdown("### Translation Summary")
-    col1, col2, col3 = st.columns(3)
-    with col1:
-        st.metric("Pages Translated", f"{start_page}-{end_page}")
-    with col2:
-        st.metric("Source Language", src_lang.split()[0])
-    with col3:
-        st.metric("Target Language", tgt_lang.split()[0])
+def show_completion(download_path: str):
+    """Display completion message and download button."""
+    st.success("Rewriting completed successfuly!")
 
-    with open("output.pdf", "rb") as pdf_file:
+    with open(download_path, "rb") as pdf_file:
         pdf_bytes = pdf_file.read()
 
-    # Download button
     st.download_button(
         label="Download PDF",
         data=pdf_bytes,
@@ -118,11 +90,11 @@ def show_instructions():
     st.markdown("""
     ### 🎯 How to use:
     1. **Upload** a PDF file using the file uploader above
-    2. **Select** source and target languages  
-    3. **Choose** the page range you want to translate
-    4. **Click** the Translate button to start the process
-    
-    *Ready to transform your documents with AI-powered translation!*
+    2. **Enter** a prompt that describes how you'd like the text rewritten
+    3. **Choose** the page range you want to rewrite
+    4. **Click** the Rewrite button to start the process
+
+    *Ready to transform your documents with AI-powered rewriting!*
     """)
 
 
@@ -130,7 +102,7 @@ def show_instructions():
 def main():
     # File upload section
     uploaded_pdf = st.file_uploader(
-        "Upload PDF file", type=["pdf"], help="Select a PDF file to translate"
+        "Upload PDF file", type=["pdf"], help="Select a PDF file to rewrite"
     )
 
     if uploaded_pdf:
@@ -144,16 +116,11 @@ def main():
             f"📄 **{uploaded_pdf.name}** ({file_size_mb:.2f} MB) loaded successfully!"
         )
 
-        # Language selection
-        col1, col2 = st.columns(2)
-        with col1:
-            src_lang = st.selectbox(
-                "From", options=COMMON_LANGUAGES, index=0, key="src_lang"
-            )
-        with col2:
-            tgt_lang = st.selectbox(
-                "To", options=COMMON_LANGUAGES, index=1, key="tgt_lang"
-            )
+        prompt = st.text_area(
+            "Rewriting prompt",
+            placeholder="e.g., Rewrite for a high school student",
+            help="Describe how you want the document to be rewritten.",
+        )
 
         # Get page count and set up page selection
         page_count = get_page_count(pdf_file)
@@ -183,39 +150,35 @@ def main():
             with pcol2:
                 end_page = st.number_input("Pages to", min_value=1, value=1, step=1)
 
-        # Translation button and logic
-        if st.button("🚀 Translate", type="primary", use_container_width=True):
+        # Rewrite button and logic
+        if st.button("✍️ Rewrite", type="primary", use_container_width=True):
             # Validate inputs
             errors = validate_inputs(
-                uploaded_pdf, src_lang, tgt_lang, start_page, end_page, page_count
+                uploaded_pdf, prompt, start_page, end_page, page_count
             )
 
             if errors:
                 for error in errors:
                     st.error(error)
             else:
-                # Perform translation with progress bar
+                # Perform rewriting with progress bar
                 progress_bar = st.progress(0)
-                with st.spinner("🔄 Translating your document..."):
+                with st.spinner("🔄 Rewriting your document..."):
                     config = load_config()
                     with open(pdf_file.name, "rb") as f:
-                        translate_pdf_preserve_layout(
+                        rewrite_pdf_preserve_layout(
                             f,
                             "output.pdf",
                             config,
-                            src_lang,
-                            tgt_lang,
+                            prompt,
                             start_page,
                             end_page,
                             progress_callback=progress_bar.progress,
                         )
 
                 progress_bar.empty()
-                st.success("✅ Translation completed successfully!")
 
-                show_translation_summary(
-                    pdf_file, start_page, end_page, src_lang, tgt_lang
-                )
+                show_completion("output.pdf")
     else:
         # Show instructions when no file uploaded
         show_instructions()


### PR DESCRIPTION
## Summary
- introduce a minimum word-count threshold for rewrite requests
- skip rewrite calls for text blocks of 10 words or fewer while preserving their original content
- avoid redacting layout blocks that fall below the threshold to keep the original PDF text untouched

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e55782f1a083239f3c7a76e541aa22